### PR TITLE
Fix build workflow secret syntax

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ on:
         default: false
 env:
   PULL_IMAGE_REGISTRY: ghcr.io/ublue-os
-  PUSH_IMAGE_REGISTRY: {{ secrets.PUSH_IMAGE_REGISTRY }}
+  PUSH_IMAGE_REGISTRY: ${{ secrets.PUSH_IMAGE_REGISTRY }}
   IMAGE_REGISTRY: ghcr.io
   ACR_REGISTRY: ${{ vars.ACR_REGISTRY }}
   ACR_NAMESPACE: ${{ vars.ACR_NAMESPACE }}


### PR DESCRIPTION
## Summary
- fix push registry variable to use the proper GitHub Actions expression syntax

## Testing
- `ruby -ryaml -e 'puts "YAML loaded successfully" if YAML.load_file(".github/workflows/build.yml")'`

------
https://chatgpt.com/codex/tasks/task_e_6846a5a494b4832e85ed48e0fb3ce2fd