### PR TITLE
Add Test Build ISO workflow

### DIFF
--- a/.github/workflows/test_build_iso.yml
+++ b/.github/workflows/test_build_iso.yml
@@ -1,0 +1,125 @@
+name: Test Build ISO
+
+on:
+  schedule:
+    - cron: "40 4 * * 1" # 4:40 utc monday
+  pull_request:
+    branches:
+      - testing
+      - unstable
+    paths-ignore:
+      - "**.md"
+      - "**.txt"
+      - "repo_content/**"
+      - "spec_files/**"
+      - "post_install_files/**"
+      - "press_kit/**"
+      - "docs/**"
+  push:
+    branches:
+      - testing
+      - unstable
+    paths-ignore:
+      - "**.md"
+      - "**.txt"
+      - "repo_content/**"
+      - "spec_files/**"
+      - "post_install_files/**"
+      - "press_kit/**"
+      - "docs/**"
+  merge_group:
+  workflow_dispatch:
+    inputs:
+      handwritten:
+        description: 'Small changelog:'
+
+env:
+  IMAGE_REGISTRY: registry.cn-hangzhou.aliyuncs.com/aerocore
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}-iso
+  cancel-in-progress: true
+
+jobs:
+  build-iso:
+    name: Build ISO
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image_name: [bazzite-deck]
+        major_version: [42]
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+
+      - name: Checkout Repo
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+
+      - name: Set Image Tag
+        id: generate-tag
+        run: |
+          TAG="testing"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+
+      - name: Set Flatpaks Directory Shortname
+        id: generate-flatpak-dir-shortname
+        run: |
+          FLATPAK_DIR_SHORTNAME="installer/kde_flatpaks"
+          if [[ "${{ matrix.image_name }}" =~ "gnome" ]]; then
+            FLATPAK_DIR_SHORTNAME="installer/gnome_flatpaks"
+          fi
+          echo "flatpak-dir-shortname=${FLATPAK_DIR_SHORTNAME}" >> $GITHUB_OUTPUT
+
+      - name: Lowercase Registry
+        id: registry_case
+        uses: ASzc/change-string-case-action@d0603cd0a7dd490be678164909f65c7737470a7f # v6
+        with:
+          string: ${{ env.IMAGE_REGISTRY }}
+
+      - name: Setup Bazzite Repo
+        run: |
+          curl -Lo ${{ github.workspace }}/bazzite.repo https://copr.fedorainfracloud.org/coprs/bazzite-org/bazzite/repo/fedora-${{ matrix.major_version }}/bazzite-org-bazzite-fedora-${{ matrix.major_version }}.repo
+
+      - name: Build ISO
+        id: build
+        uses: jasonn3/build-container-installer@f09a756b7a1205f121d8508f1171759328b95d2c # v1.2.4
+        with:
+          arch: x86_64
+          image_name: ${{ matrix.image_name }}
+          image_repo: ${{ steps.registry_case.outputs.lowercase }}
+          variant: 'Kinoite'
+          version: ${{ matrix.major_version }}
+          image_tag: ${{ steps.generate-tag.outputs.tag }}
+          secure_boot_key_url: '${{ github.server_url }}/${{ github.repository }}/raw/main/secure_boot.der'
+          enrollment_password: 'universalblue'
+          iso_name: ${{ matrix.image_name }}-${{ steps.generate-tag.outputs.tag }}-amd64.iso
+          enable_cache_dnf: "false"
+          enable_cache_skopeo: "false"
+          flatpak_remote_refs_dir: ${{ steps.generate-flatpak-dir-shortname.outputs.flatpak-dir-shortname }}
+          enable_flatpak_dependencies: "false"
+          additional_templates: '/github/workspace/installer/lorax_templates/remove_root_password_prompt.tmpl /github/workspace/installer/lorax_templates/set_default_user.tmpl'
+          repos: '/github/workspace/bazzite.repo /etc/yum.repos.d/fedora.repo /etc/yum.repos.d/fedora-updates.repo'
+
+      - name: Move ISOs to Upload Directory
+        id: upload-directory
+        run: |
+          ISO_UPLOAD_DIR=${{ github.workspace }}/upload
+          mkdir ${ISO_UPLOAD_DIR}
+          mv ${{ steps.build.outputs.iso_path }}/${{ steps.build.outputs.iso_name }} ${ISO_UPLOAD_DIR}
+          mv ${{ steps.build.outputs.iso_path }}/${{ steps.build.outputs.iso_name }}-CHECKSUM ${ISO_UPLOAD_DIR}
+          echo "iso-upload-dir=${ISO_UPLOAD_DIR}" >> $GITHUB_OUTPUT
+
+      - name: Upload ISOs and Checksum to Job Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ matrix.image_name }}-${{ steps.generate-tag.outputs.tag }}-${{ matrix.major_version }}
+          path: ${{ steps.upload-directory.outputs.iso-upload-dir }}
+          if-no-files-found: error
+          retention-days: 0
+          compression-level: 0
+          overwrite: true


### PR DESCRIPTION
## Summary
- add Test Build ISO workflow to build a single bazzite-deck image for Fedora 42 and upload artifacts

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68ab961068e4832eb4d5c44f57a2502a