### PR TITLE
chore(ci): log iso checksum

### DIFF
--- a/.github/workflows/test_build_iso.yml
+++ b/.github/workflows/test_build_iso.yml
@@ -125,6 +125,11 @@ jobs:
           additional_templates: '/github/workspace/installer/lorax_templates/remove_root_password_prompt.tmpl /github/workspace/installer/lorax_templates/set_default_user.tmpl'
           repos: '/github/workspace/bazzite.repo /etc/yum.repos.d/fedora.repo /etc/yum.repos.d/fedora-updates.repo'
 
+      - name: Display ISO Checksum
+        shell: bash
+        run: |
+          cat ${{ steps.build.outputs.iso_path }}/${{ steps.build.outputs.iso_name }}-CHECKSUM
+
       - name: Move ISOs to Upload Directory
         id: upload-directory
         shell: bash


### PR DESCRIPTION
## Summary
- show ISO checksum after build in `test_build_iso` workflow

## Testing
- `just just-check` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e74d26b4832e96ac5104d4d1fd57