### PR TITLE
chore: enable Decky loader service for all variants

### DIFF
--- a/system_files/shared/usr/lib/systemd/user/decky-loader.service
+++ b/system_files/shared/usr/lib/systemd/user/decky-loader.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Install or update Decky Loader for current user
+After=gamescope-session.target
+PartOf=gamescope-session.target
+ConditionUser=!@system
+
+[Service]
+Type=oneshot
+ExecStart=/usr/share/decky-installer/decky-updater.sh
+
+[Install]
+WantedBy=gamescope-session.target
+


### PR DESCRIPTION
## Summary
- add decky-loader systemd service to shared system files so all variants auto-install Decky

## Testing
- `pre-commit run --files system_files/shared/usr/lib/systemd/user/decky-loader.service` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc58ae08d4832e9c509bdad1f0d2f1